### PR TITLE
catch exceptions from paint method

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 2020-03-12 Jan Kotanski <jan.kotanski@desy.de>
+	* catch exceptions from paint method
+	* tagged as 2.38.3
+
+2020-03-12 Jan Kotanski <jan.kotanski@desy.de>
 	* remove callback on disconnect Tango Events
 	* tagged as 2.38.2
 

--- a/lavuelib/imageDisplayWidget.py
+++ b/lavuelib/imageDisplayWidget.py
@@ -69,8 +69,10 @@ class SafeImageItem(_pg.ImageItem):
             _pg.ImageItem.paint(self, p, *args)
         except ValueError as e:
             logger.warning(str(e))
-            # print(str(e))
-            # print("Shape mismatch: skip painting")
+        except TypeError as e:
+            logger.warning(str(e))
+        except Exception as e:
+            logger.warning(str(e))
 
 
 class AxesParameters(object):

--- a/lavuelib/release.py
+++ b/lavuelib/release.py
@@ -26,4 +26,4 @@
 """ release version """
 
 #: (:obj:`str`) the live viewer version
-__version__ = "2.38.2"
+__version__ = "2.38.3"


### PR DESCRIPTION
It catches the following exception
```
haspp06eval03:~$lavue -m expert -a haspp06:10000/p06/lavuecontroller/exp.01

(python:19348): Gtk-WARNING **: Theme parsing error: gtk-widgets.css:1214:18: Not using units is deprecated. Assuming 'px'.
Gtk-Message: GtkDialog mapped without a transient parent. This is discouraged.
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/lavuelib/imageDisplayWidget.py", line 69, in paint
    _pg.ImageItem.paint(self, p, *args)
  File "/usr/lib/python2.7/dist-packages/pyqtgraph/graphicsItems/ImageItem.py", line 411, in paint
    self.render()
  File "/usr/lib/python2.7/dist-packages/pyqtgraph/graphicsItems/ImageItem.py", line 360, in render
    w = Point(x-o).length()
TypeError: unsupported operand type(s) for -: 'NoneType' and 'NoneType'
Aborted
```