### PR TITLE
Issue 539: improve currenttime implementation with tzlocal module

### DIFF
--- a/lavuelib/filewriter.py
+++ b/lavuelib/filewriter.py
@@ -526,7 +526,11 @@ class FTFile(FTObject):
         :rtype: :obj:`str`
         """
         tzone = time.tzname[0]
-        tz = pytz.timezone(tzone)
+        try:
+            tz = pytz.timezone(tzone)
+        except Exception:
+            import tzlocal
+            tz = tzlocal.get_localzone()
         fmt = '%Y-%m-%dT%H:%M:%S.%f%z'
         starttime = tz.localize(datetime.datetime.now())
         return str(starttime.strftime(fmt))

--- a/lavuelib/imageSource.py
+++ b/lavuelib/imageSource.py
@@ -203,7 +203,11 @@ def currenttime():
     # does not work on py2 and old py3
     # return datetime.datetime.utcnow().astimezone().isoformat()
     tzone = time.tzname[0]
-    tz = pytz.timezone(tzone)
+    try:
+        tz = pytz.timezone(tzone)
+    except Exception:
+        import tzlocal
+        tz = tzlocal.get_localzone()
     fmt = '%Y-%m-%dT%H:%M:%S.%f%z'
     starttime = tz.localize(datetime.datetime.now())
     return str(starttime.strftime(fmt))


### PR DESCRIPTION
It resolves #539 by using time zone from tzlocal module if pytz fails 