### PR TITLE
Issue 544: fixes for imageFileLoader and PyTine.get command in imageSources

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-08-06 Jan Kotanski <jan.kotanski@desy.de>
+	* add mutex for PyTine.get command in imageSources
+	* use TIFLoader when fabio does not work
+	* tagged as 2.64.1
+
 2021-07-30 Jan Kotanski <jan.kotanski@desy.de>
 	* add the --no-space-instance command line parameter
 	* improve implementation of the currenttime() methods with tzlocal import

--- a/lavuelib/imageFileHandler.py
+++ b/lavuelib/imageFileHandler.py
@@ -441,6 +441,8 @@ class ImageFileHandler(object):
             if FABIO:
                 self.__image = fabio.open(fname)
                 self.__data = self.__image.data
+                if self.__data is None:
+                    raise Exception("no data")
                 if "_array_data.header_convention" \
                    in self.__image.header.keys():
                     rmeta = self.__image.header["_array_data.header_contents"]

--- a/lavuelib/imageSource.py
+++ b/lavuelib/imageSource.py
@@ -158,6 +158,8 @@ else:
     bytes = str
 
 
+globalmutex = QtCore.QMutex()
+
 logger = logging.getLogger("lavue")
 
 #: (:obj:`bool`) PyTango bug #213 flag related to EncodedAttributes in python3
@@ -2642,9 +2644,12 @@ class TinePropSource(BaseSource):
             return "No Tine Property defined", "__ERROR__", None
         try:
             interval = int(dataFetchThread.GLOBALREFRESHRATE*1000)
-            prop = PyTine.get(address=self.__address,
-                              property=self.__prop,
-                              timeout=interval)
+            import copy
+            with QtCore.QMutexLocker(globalmutex):
+                prop = PyTine.get(address=self.__address,
+                                  property=self.__prop,
+                                  timeout=interval)
+                prop = copy.deepcopy(prop)
             rawdata = prop["data"]
 
             if "imageMatrix" in rawdata:

--- a/lavuelib/imageSource.py
+++ b/lavuelib/imageSource.py
@@ -2644,12 +2644,10 @@ class TinePropSource(BaseSource):
             return "No Tine Property defined", "__ERROR__", None
         try:
             interval = int(dataFetchThread.GLOBALREFRESHRATE*1000)
-            import copy
             with QtCore.QMutexLocker(globalmutex):
                 prop = PyTine.get(address=self.__address,
                                   property=self.__prop,
                                   timeout=interval)
-                prop = copy.deepcopy(prop)
             rawdata = prop["data"]
 
             if "imageMatrix" in rawdata:

--- a/lavuelib/release.py
+++ b/lavuelib/release.py
@@ -26,4 +26,4 @@
 """ release version """
 
 #: (:obj:`str`) the live viewer version
-__version__ = "2.64.0"
+__version__ = "2.64.1"


### PR DESCRIPTION
It resolves #544 and #545 If fixes for imageFileLoader by throwing an exception when fabio cannot read an image
and adding mutex and deepcopy around PyTine.get command in imageSources