### PR TITLE
provide a http:// and https:// link view via a tango File source

### DIFF
--- a/lavuelib/imageSource.py
+++ b/lavuelib/imageSource.py
@@ -619,6 +619,11 @@ class TangoFileSource(BaseSource):
                         filename = filename[(len(sm) + 1):]
                         scheme = "h5file"
                         break
+            if not scheme:
+                for sm in ("http://", "https://"):
+                    if filename.startswith(sm):
+                        scheme = "httplink"
+                        break
             if self.__dproxy:
                 dattr = self.__dproxy.read().value
                 filename = "%s/%s" % (dattr, filename)
@@ -688,7 +693,10 @@ class TangoFileSource(BaseSource):
                         self.__nxsfile, self.__nxsfield, self.__frame)
                     self.__frame += 1
                     return (np.transpose(image), '%s' % (filename), metadata)
-
+            elif scheme in ["httplink"]:
+                httpSource = HTTPSource()
+                httpSource.setConfiguration(filename)
+                return httpSource.getData()
             else:
                 self.__resetnexus()
                 fh = imageFileHandler.ImageFileHandler(str(filename))


### PR DESCRIPTION
Dear developers, I would first like to thank you for such excellent software.

In this pull request I would like to add the ability to provide http:// and https:// links via Tango File. If there can be a file path there, why can't there be an image link. 🤷

In many cases it can be much easier to bring up an http server on the host machine and share an image folder than to set up a file system, especially in newer networks.

Best wishes
Leonid