### PR TITLE
split zmq source parameters with : and not with /

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-05-19 Jan Garrevoet <jan.garrevoet@desy.de>
+	* Breaking change in the ZMQ config layout. topic and HWM are not
+	separated with a slahs but with a colon to allow for topics to contain
+	slashes.
+
 2023-03-31 Jan Kotanski <jan.kotanski@desy.de>
 	* enlarge GLOBALREFRESHTIME when it is too small
 	* change GLOBALREFRESHRATE  to GLOBALREFRESHTIME

--- a/doc/gui/imagesources/zmqstream.rst
+++ b/doc/gui/imagesources/zmqstream.rst
@@ -10,7 +10,7 @@ Images from a simple ZMQ server, e.g. lavuezmqstreamfromtango SERVER. It is used
 
 The **ZMQ Stream** image source frame contains the following fields:
 
-*    **ZMQ Server:** selects the zmq server host and zmq  data port. Moreover the user can also select the required zmq topic and ZMQ HWM (how many images is in buffer), i.e. `host:port[/topic[/HWM]]`
+*    **ZMQ Server:** selects the zmq server host and zmq  data port. Moreover the user can also select the required zmq topic and ZMQ HWM (how many images is in buffer), i.e. `host:port[:topic[:HWM]]`
 *    **DataSource:** name of zmq topic. Possible datasources can be predefined in the configuration or sent in ZMQ metadata.
 *    **Status:** shows the connection status. It also displays a port of ZMQ security stream if it is enabled.
 *    **Start/Stop** button to launch or interrupt image querying

--- a/lavuelib/help/_sources/gui/imagesources/zmqstream.rst.txt
+++ b/lavuelib/help/_sources/gui/imagesources/zmqstream.rst.txt
@@ -10,7 +10,7 @@ Images from a simple ZMQ server, e.g. lavuezmqstreamfromtango SERVER. It is used
 
 The **ZMQ Stream** image source frame contains the following fields:
 
-*    **ZMQ Server:** selects the zmq server host and zmq  data port. Moreover the user can also select the required zmq topic and ZMQ HWM (how many images is in buffer), i.e. `host:port[/topic[/HWM]]`
+*    **ZMQ Server:** selects the zmq server host and zmq  data port. Moreover the user can also select the required zmq topic and ZMQ HWM (how many images is in buffer), i.e. `host:port[:topic[:HWM]]`
 *    **DataSource:** name of zmq topic. Possible datasources can be predefined in the configuration or sent in ZMQ metadata.
 *    **Status:** shows the connection status. It also displays a port of ZMQ security stream if it is enabled.
 *    **Start/Stop** button to launch or interrupt image querying

--- a/lavuelib/help/gui/imagesources/zmqstream.html
+++ b/lavuelib/help/gui/imagesources/zmqstream.html
@@ -60,7 +60,7 @@
 </figure>
 <p>The <strong>ZMQ Stream</strong> image source frame contains the following fields:</p>
 <ul class="simple">
-<li><p><strong>ZMQ Server:</strong> selects the zmq server host and zmq  data port. Moreover the user can also select the required zmq topic and ZMQ HWM (how many images is in buffer), i.e. <cite>host:port[/topic[/HWM]]</cite></p></li>
+<li><p><strong>ZMQ Server:</strong> selects the zmq server host and zmq  data port. Moreover the user can also select the required zmq topic and ZMQ HWM (how many images is in buffer), i.e. <cite>host:port[:topic[:HWM]]</cite></p></li>
 <li><p><strong>DataSource:</strong> name of zmq topic. Possible datasources can be predefined in the configuration or sent in ZMQ metadata.</p></li>
 <li><p><strong>Status:</strong> shows the connection status. It also displays a port of ZMQ security stream if it is enabled.</p></li>
 <li><p><strong>Start/Stop</strong> button to launch or interrupt image querying</p></li>

--- a/lavuelib/imageSource.py
+++ b/lavuelib/imageSource.py
@@ -1793,10 +1793,19 @@ class ZMQSource(BaseSource):
         """ connects the source
         """
         try:
-            shost = str(self._configuration).split("/")
-            host, port = str(shost[0]).split(":")
-            self.__topic = tobytes(shost[1] if len(shost) > 1 else "")
-            hwm = int(shost[2]) if (len(shost) > 2 and shost[2]) else 2
+            conf = self._configuration.split(":")
+            host = conf[0]
+            port = conf[1]
+            if len(conf) > 2:
+                self.__topic = tobytes(conf[2])
+            else:
+                self.__topic == b""
+
+            if len(conf) > 3:
+                hwm = int(conf[3])
+            else:
+                hwm = 2
+
             if not self._initiated:
                 if self.__socket:
                     self.disconnect()
@@ -1813,7 +1822,6 @@ class ZMQSource(BaseSource):
                     self.__socket.setsockopt(zmq.SUBSCRIBE,
                                              self.__topic)
                     self.__socket.setsockopt(zmq.SUBSCRIBE, b"datasources")
-                    # self.__socket.setsockopt(zmq.SUBSCRIBE, "")
                     self.__socket.connect(self.__bindaddress)
                 time.sleep(0.2)
             return True

--- a/lavuelib/sourceWidget.py
+++ b/lavuelib/sourceWidget.py
@@ -2273,7 +2273,7 @@ class ZMQSourceWidget(SourceBaseWidget):
                         shost[1] = str(text)
                     else:
                         shost.append(str(text))
-                    hosturl = "/".join(shost)
+                    hosturl = ":".join(shost)
             except Exception:
                 hosturl = ""
         return hosturl

--- a/lavuelib/ui/ZMQSourceWidget.ui
+++ b/lavuelib/ui/ZMQSourceWidget.ui
@@ -19,7 +19,7 @@
      <item row="0" column="0">
       <widget class="QLabel" name="pickleLabel">
        <property name="toolTip">
-        <string>zmq server, port and topic, hwm (optional): server:port[/topic][/hwm]
+        <string>zmq server, port and topic, hwm (optional): server:port[:topic][:hwm]
 e.g. haso228:9999/10001 or :5553</string>
        </property>
        <property name="text">
@@ -50,7 +50,7 @@ e.g. haso228:9999/10001 or :5553</string>
      <item row="0" column="1">
       <widget class="QComboBox" name="pickleComboBox">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;zmq server, port and topic, hwm (optional): server:port[/topic][/hwm]&lt;/p&gt;&lt;p&gt;e.g. haso228:9999/10001 or :5553&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;zmq server, port and topic, hwm (optional): server:port[:topic][:hwm]&lt;/p&gt;&lt;p&gt;e.g. haso228:9999/10001 or :5553&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="editable">
         <bool>true</bool>

--- a/man/lavuelib.1
+++ b/man/lavuelib.1
@@ -681,7 +681,7 @@ Images from a simple ZMQ server, e.g. lavuezmqstreamfromtango SERVER. It is used
 The \fBZMQ Stream\fP image source frame contains the following fields:
 .INDENT 0.0
 .IP \(bu 2
-\fBZMQ Server:\fP selects the zmq server host and zmq  data port. Moreover the user can also select the required zmq topic and ZMQ HWM (how many images is in buffer), i.e. \fIhost:port[/topic[/HWM]]\fP
+\fBZMQ Server:\fP selects the zmq server host and zmq  data port. Moreover the user can also select the required zmq topic and ZMQ HWM (how many images is in buffer), i.e. \fIhost:port[:topic[:HWM]]\fP
 .IP \(bu 2
 \fBDataSource:\fP name of zmq topic. Possible datasources can be predefined in the configuration or sent in ZMQ metadata.
 .IP \(bu 2


### PR DESCRIPTION
Closes #710 
This change is breaking compatibility for people that are using the HWM.