### PR TITLE
Add BVdata decoder to TangoAttribute and TangoEvent sources.

### DIFF
--- a/lavuelib/imageSource.py
+++ b/lavuelib/imageSource.py
@@ -36,6 +36,8 @@ import glob
 from . import dataFetchThread
 from .sardanaUtils import debugmethod, numpyEncoder
 
+import base64
+
 try:
     import requests
     #: (:obj:`bool`) requests imported
@@ -1090,6 +1092,103 @@ class DATAARRAYdecoder(object):
         return self.__value
 
 
+class BVdecorder(object):
+
+    """"BVdata Lima decoder
+    """
+
+    @debugmethod
+    def __init__(self):
+        #: (:obj:`str`) decoder name
+        self.name = "LIMA_BV_DATA"
+        self.format = None
+        self.dtype = None
+
+        self.__value = None
+        self.__data = None
+        self.__header = {}
+
+        self.__fixedHeaderSize = None
+
+    @debugmethod
+    def load(self, data):
+        """  loads encoded data
+
+        :param data: encoded data
+        :type data: [:obj:`str`, :obj:`str`]
+        """
+        logger.debug(
+            "lavuelib.imageSource.BVdecorder.load:  %s" % str(data[0]))
+        self.__data = data
+        self.format = data[0]
+        # Unpack only the fixed header portion
+        self._loadHeader(data[1])
+        self.__value = None
+
+    @debugmethod
+    def _loadHeader(self, headerData):
+        """ loads the image header
+
+        :param headerData: buffer with header data
+        :type headerData: :obj:`str`
+        """
+        hdr = struct.unpack(self.format, headerData)
+        self.__header = {}
+        self.__header['timestamp']          = hdr[0]
+        self.__header['framenb']            = hdr[1]
+        self.__header['X']                  = hdr[2]
+        self.__header['Y']                  = hdr[3]
+        self.__header['I']                  = hdr[4]
+        self.__header['maxI']               = hdr[5]
+        self.__header['roi_top_x']          = hdr[6]
+        self.__header['roi_top_y']          = hdr[7]
+        self.__header['roi_size_getWidth']  = hdr[8]
+        self.__header['roi_size_getHeight'] = hdr[9]
+        self.__header['fwhm_x']             = hdr[10]
+        self.__header['fwhm_y']             = hdr[11]
+        self.__header['prof_x']             = hdr[12]
+        self.__header['prof_y']             = hdr[13]
+        self.__header['jpegData']           = hdr[14]
+
+
+        # Since JPEG images are RGB with 8 bits per channel,
+        # we set the dtype here.
+        self.dtype = 'uint8'
+
+    @debugmethod
+    def decode(self):
+        """ provides the decoded data
+
+        :returns: the decoded data if data was loaded
+        :rtype: :class:`numpy.ndarray`
+        """
+        if not self.__header or not self.__data:
+            return
+        if self.__value is None:
+            decoded = base64.b64decode(self.__header['jpegData'])
+            image = PIL.Image.open(BytesIO(decoded))
+            self.__value = np.transpose(image, (0, 1, 2))
+        return self.__value
+
+    def shape(self):
+        """ provides the data shape
+
+        :returns: the data shape if data was loaded
+        :rtype: :obj:`list` <:obj:`int` >
+        """
+        if self.__header:
+            #ab
+            return [2,self.__header['roi_size_getWidth']]
+
+    def getMetadata(self):
+        meta = self.__header.copy()
+        meta.pop('jpegData', None)
+        for key in ['prof_x', 'prof_y']:
+            if key in meta and isinstance(meta[key], bytes):
+                meta[key] = base64.b64encode(meta[key]).decode('utf-8')
+        return json.dumps(meta)
+
+
 class TangoAttrSource(BaseSource):
 
     """ image source as IMAGE Tango attribute
@@ -1112,6 +1211,7 @@ class TangoAttrSource(BaseSource):
             "LIMA_VIDEO_IMAGE": VDEOdecoder(),
             "VIDEO_IMAGE": VDEOdecoder(),
             "DATA_ARRAY": DATAARRAYdecoder(),
+            "BV_DATA": BVdecorder()
         }
         #: (:dict: <:obj:`str`, :obj:`str`>)
         #:      dictionary of tango decorders
@@ -1180,13 +1280,20 @@ class TangoAttrSource(BaseSource):
                     return (np.transpose(data),
                             '%s  (%s)' % (
                                 self._configuration, str(attr.time)), "")
+                elif avalue[0] is not None and attr.name == 'bvdata':
+                    dec = self.__decoders['BV_DATA']
+                    dec.load(avalue)
+                    shape = dec.shape()
+                    if shape is None or shape[0] <= 0 or shape[1] <= 0:
+                        return None, None, None
+                    return (dec.decode().T,
+                            '%s  (%s)' % (
+                                self._configuration, str(attr.time)),
+                            dec.getMetadata())
                 else:
                     dec = self.__decoders[avalue[0]]
                     dec.load(avalue)
-                    if dec.frameNumber() is not None:
-                        fnumber = dec.frameNumber()
-                    else:
-                        fnumber = ""
+                    fnumber = dec.frameNumber() or ""
                     shape = dec.shape()
                     if shape is None or shape[0] <= 0 or shape[1] <= 0:
                         return None, None, None
@@ -1357,7 +1464,8 @@ class TangoEventsSource(BaseSource):
         self.__decoders = {
             "LIMA_VIDEO_IMAGE": VDEOdecoder(),
             "VIDEO_IMAGE": VDEOdecoder(),
-            "DATA_ARRAY": DATAARRAYdecoder()
+            "DATA_ARRAY": DATAARRAYdecoder(),
+            'BV_DATA': BVdecorder()
         }
         #: (:dict: <:obj:`str`, :obj:`str`>)
         #:      dictionary of tango decorders
@@ -1411,14 +1519,21 @@ class TangoEventsSource(BaseSource):
                                     self._configuration,
                                     str(self.attr.time)),
                                 "")
+                    elif avalue[0] is not None and self.attr.name == 'bvdata':
+                        dec = self.__decoders['BV_DATA']
+                        dec.load(avalue)
+                        shape = dec.shape()
+                        if shape is None or shape[0] <= 0 or shape[1] <= 0:
+                            return None, None, None
+                        return (dec.decode().T,
+                                '%s  (%s)' % (
+                                    self._configuration, str(self.attr.time)),
+                                dec.getMetadata())
                     else:
                         dec = self.__decoders[avalue[0]]
                         dec.load(avalue)
+                        fnumber = dec.frameNumber() or ""
                         shape = dec.shape()
-                        if dec.frameNumber() is not None:
-                            fnumber = dec.frameNumber()
-                        else:
-                            fnumber = ""
                         if shape is None or shape[0] <= 0 or shape[1] <= 0:
                             return None, None, None
                         return (dec.decode().T,

--- a/lavuelib/imageSource.py
+++ b/lavuelib/imageSource.py
@@ -1134,22 +1134,21 @@ class BVdecorder(object):
         """
         hdr = struct.unpack(self.format, headerData)
         self.__header = {}
-        self.__header['timestamp']          = hdr[0]
-        self.__header['framenb']            = hdr[1]
-        self.__header['X']                  = hdr[2]
-        self.__header['Y']                  = hdr[3]
-        self.__header['I']                  = hdr[4]
-        self.__header['maxI']               = hdr[5]
-        self.__header['roi_top_x']          = hdr[6]
-        self.__header['roi_top_y']          = hdr[7]
-        self.__header['roi_size_getWidth']  = hdr[8]
+        self.__header['timestamp'] = hdr[0]
+        self.__header['framenb'] = hdr[1]
+        self.__header['X'] = hdr[2]
+        self.__header['Y'] = hdr[3]
+        self.__header['I'] = hdr[4]
+        self.__header['maxI'] = hdr[5]
+        self.__header['roi_top_x'] = hdr[6]
+        self.__header['roi_top_y'] = hdr[7]
+        self.__header['roi_size_getWidth'] = hdr[8]
         self.__header['roi_size_getHeight'] = hdr[9]
-        self.__header['fwhm_x']             = hdr[10]
-        self.__header['fwhm_y']             = hdr[11]
-        self.__header['prof_x']             = hdr[12]
-        self.__header['prof_y']             = hdr[13]
-        self.__header['jpegData']           = hdr[14]
-
+        self.__header['fwhm_x'] = hdr[10]
+        self.__header['fwhm_y'] = hdr[11]
+        self.__header['prof_x'] = hdr[12]
+        self.__header['prof_y'] = hdr[13]
+        self.__header['jpegData'] = hdr[14]
 
         # Since JPEG images are RGB with 8 bits per channel,
         # we set the dtype here.
@@ -1177,8 +1176,7 @@ class BVdecorder(object):
         :rtype: :obj:`list` <:obj:`int` >
         """
         if self.__header:
-            #ab
-            return [2,self.__header['roi_size_getWidth']]
+            return [2, self.__header['roi_size_getWidth']]
 
     def getMetadata(self):
         meta = self.__header.copy()

--- a/test/TangoAttrImageSource_test.py
+++ b/test/TangoAttrImageSource_test.py
@@ -2151,7 +2151,7 @@ class TangoAttrImageSourceTest(unittest.TestCase):
     def _make_bvdata_payload(
             width=4, height=3,
             timestamp=1234567890.0, framenb=42,
-            X=1.5, Y=2.5, I=100.0, maxI=255.0,
+            X=1.5, Y=2.5, intensity=100.0, maxI=255.0,
             roi_top_x=0.0, roi_top_y=0.0,
             fwhm_x=1.1, fwhm_y=2.2):
         """ builds a (format_string, packed_binary) tuple for BVdecorder """
@@ -2167,7 +2167,7 @@ class TangoAttrImageSourceTest(unittest.TestCase):
 
         fmt = 'd I d d d d d d d d d d 5s 5s %ds' % len(jpeg_b64)
         packed = struct.pack(
-            fmt, timestamp, framenb, X, Y, I, maxI,
+            fmt, timestamp, framenb, X, Y, intensity, maxI,
             roi_top_x, roi_top_y, float(width), float(height),
             fwhm_x, fwhm_y, prof_x, prof_y, jpeg_b64)
         return fmt, packed, pixels, prof_x, prof_y
@@ -2201,7 +2201,7 @@ class TangoAttrImageSourceTest(unittest.TestCase):
 
         fmt, packed, _, prof_x, prof_y = self._make_bvdata_payload(
             timestamp=11.0, framenb=7, X=3.0, Y=4.0,
-            I=50.0, maxI=200.0)
+            intensity=50.0, maxI=200.0)
         dec = lavuelib.imageSource.BVdecorder()
         dec.load((fmt, packed))
 

--- a/test/TangoAttrImageSource_test.py
+++ b/test/TangoAttrImageSource_test.py
@@ -30,7 +30,11 @@ import binascii
 import time
 import logging
 import json
+import base64
+from io import BytesIO
 import numpy as np
+import PIL
+import PIL.Image
 
 import argparse
 import lavuelib
@@ -2142,6 +2146,117 @@ class TangoAttrImageSourceTest(unittest.TestCase):
         self.assertEqual(tw2.shape, (4, 3, 2))
         self.assertEqual(ad.shape(), [4, 3, 2])
         self.assertTrue(np.allclose(dw2, tw2))
+
+    @staticmethod
+    def _make_bvdata_payload(
+            width=4, height=3,
+            timestamp=1234567890.0, framenb=42,
+            X=1.5, Y=2.5, I=100.0, maxI=255.0,
+            roi_top_x=0.0, roi_top_y=0.0,
+            fwhm_x=1.1, fwhm_y=2.2):
+        """ builds a (format_string, packed_binary) tuple for BVdecorder """
+        # create a small RGB JPEG in memory
+        pixels = np.arange(width * height * 3, dtype=np.uint8).reshape(
+            (height, width, 3))
+        buf = BytesIO()
+        PIL.Image.fromarray(pixels, 'RGB').save(buf, format='JPEG')
+        jpeg_b64 = base64.b64encode(buf.getvalue())
+
+        prof_x = b'\x01\x02\x03\x04\x05'
+        prof_y = b'\x06\x07\x08\x09\x0a'
+
+        fmt = 'd I d d d d d d d d d d 5s 5s %ds' % len(jpeg_b64)
+        packed = struct.pack(
+            fmt, timestamp, framenb, X, Y, I, maxI,
+            roi_top_x, roi_top_y, float(width), float(height),
+            fwhm_x, fwhm_y, prof_x, prof_y, jpeg_b64)
+        return fmt, packed, pixels, prof_x, prof_y
+
+    def test_BV_DATA_decoder(self):
+        fun = sys._getframe().f_code.co_name
+        print("Run: %s.%s() " % (self.__class__.__name__, fun))
+
+        fmt, packed, pixels, _, _ = self._make_bvdata_payload()
+        dec = lavuelib.imageSource.BVdecorder()
+
+        self.assertEqual(dec.name, "LIMA_BV_DATA")
+        # before load
+        self.assertIsNone(dec.decode())
+        self.assertIsNone(dec.shape())
+
+        dec.load((fmt, packed))
+        self.assertEqual(dec.dtype, 'uint8')
+        self.assertEqual(dec.shape(), [2, 4.0])
+
+        result = dec.decode()
+        self.assertIsNotNone(result)
+        self.assertEqual(result.dtype, np.uint8)
+        # JPEG is lossy so just check shape matches the source image
+        self.assertEqual(result.shape[0], pixels.shape[0])
+        self.assertEqual(result.shape[1], pixels.shape[1])
+
+    def test_BV_DATA_decoder_metadata(self):
+        fun = sys._getframe().f_code.co_name
+        print("Run: %s.%s() " % (self.__class__.__name__, fun))
+
+        fmt, packed, _, prof_x, prof_y = self._make_bvdata_payload(
+            timestamp=11.0, framenb=7, X=3.0, Y=4.0,
+            I=50.0, maxI=200.0)
+        dec = lavuelib.imageSource.BVdecorder()
+        dec.load((fmt, packed))
+
+        meta = json.loads(dec.getMetadata())
+
+        self.assertNotIn('jpegData', meta)
+        self.assertAlmostEqual(meta['timestamp'], 11.0)
+        self.assertEqual(meta['framenb'], 7)
+        self.assertAlmostEqual(meta['X'], 3.0)
+        self.assertAlmostEqual(meta['Y'], 4.0)
+        self.assertAlmostEqual(meta['I'], 50.0)
+        self.assertAlmostEqual(meta['maxI'], 200.0)
+        self.assertAlmostEqual(meta['fwhm_x'], 1.1)
+        self.assertAlmostEqual(meta['fwhm_y'], 2.2)
+
+        # prof_x/prof_y should be base64-encoded strings
+        self.assertEqual(
+            base64.b64decode(meta['prof_x']), prof_x)
+        self.assertEqual(
+            base64.b64decode(meta['prof_y']), prof_y)
+
+    def test_BV_DATA_decoder_no_data(self):
+        fun = sys._getframe().f_code.co_name
+        print("Run: %s.%s() " % (self.__class__.__name__, fun))
+
+        dec = lavuelib.imageSource.BVdecorder()
+        self.assertIsNone(dec.decode())
+        self.assertIsNone(dec.shape())
+        self.assertEqual(dec.dtype, None)
+
+    def test_BV_DATA_decoder_reload(self):
+        fun = sys._getframe().f_code.co_name
+        print("Run: %s.%s() " % (self.__class__.__name__, fun))
+
+        dec = lavuelib.imageSource.BVdecorder()
+
+        # first load: 4x3 image
+        fmt1, packed1, _, _, _ = self._make_bvdata_payload(
+            width=4, height=3, framenb=1)
+        dec.load((fmt1, packed1))
+        result1 = dec.decode()
+        self.assertEqual(result1.shape[0], 3)
+        self.assertEqual(result1.shape[1], 4)
+
+        # second load: 6x5 image — cache must be invalidated
+        fmt2, packed2, _, _, _ = self._make_bvdata_payload(
+            width=6, height=5, framenb=2)
+        dec.load((fmt2, packed2))
+        result2 = dec.decode()
+        self.assertEqual(result2.shape[0], 5)
+        self.assertEqual(result2.shape[1], 6)
+
+        # verify metadata updated too
+        meta = json.loads(dec.getMetadata())
+        self.assertEqual(meta['framenb'], 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The bvdata is the attribute in the BPM lima device server which is a dev encoded containing a header and a base64 encoded image. With the image there is also metadata with computations done by the bpm device server. 
The BVdecorder in this pull request makes it possible to visualize the images from lavue.  